### PR TITLE
Make strscan behavior consistent across platforms and with blua

### DIFF
--- a/src/lj_strscan.c
+++ b/src/lj_strscan.c
@@ -577,23 +577,14 @@ StrScanFmt lj_strscan_scan(const uint8_t *p, MSize len, TValue *o,
     {
       // make behaviour consistent between platforms
       // by replicating strtols cutoff behaviour for 32bit wide long
-      // on a 10 base (standart blua uses it)
 
-      /*
-      * ..if the range for longs is
-      * [-2147483648..2147483647] and the input base is 10,
-      * cutoff will be set to 214748364...
-      */
-
-#define STRCUTOFF 214748364
+      int32_t cutoff = neg ? -(int32_t)INT32_MIN : INT32_MAX;
+      int32_t cutlim = cutoff % base;
+      cutoff /= base;
 
       int64_t x2 = (int64_t)(neg ? ~x+1u : x);
-      if (x2 > STRCUTOFF)
-        x2 = INT32_MAX;
-      else if (x2 < STRCUTOFF)
-        x2 = INT32_MIN;
-
-#undef STRCUTOFF
+      if (x2 > cutoff || (x2 == cutoff && (x % base) > cutlim))
+        x2 = neg ? INT32_MIN : INT32_MAX;
 
       if (fmt == STRSCAN_NUM)
         setnumV(o, (lua_Number)(int32_t)x2);

--- a/src/lj_strscan.c
+++ b/src/lj_strscan.c
@@ -578,9 +578,9 @@ StrScanFmt lj_strscan_scan(const uint8_t *p, MSize len, TValue *o,
       // make behaviour consistent between platforms
       // by replicating strtols cutoff behaviour for 32bit wide long
 
-      int32_t cutoff = neg ? -(int32_t)INT32_MIN : INT32_MAX;
-      int32_t cutlim = cutoff % base;
-      cutoff /= base;
+      uint32_t cutoff = neg ? -(uint32_t)INT32_MIN : INT32_MAX;
+      int32_t cutlim = cutoff % (unsigned int)base;
+      cutoff /= (unsigned int)base;
 
       int64_t x2 = (int64_t)(neg ? ~x+1u : x);
       if (x2 > cutoff || (x2 == cutoff && (x % base) > cutlim))

--- a/src/lj_strscan.c
+++ b/src/lj_strscan.c
@@ -574,10 +574,32 @@ StrScanFmt lj_strscan_scan(const uint8_t *p, MSize len, TValue *o,
       fmt = strscan_bin(sp, o, fmt, opt, ex, neg, dig);
     else
 #if LJ_INTONLY
+    {
+      // make behaviour consistent between platforms
+      // by replicating strtols cutoff behaviour for 32bit wide long
+      // on a 10 base (standart blua uses it)
+
+      /*
+      * ..if the range for longs is
+      * [-2147483648..2147483647] and the input base is 10,
+      * cutoff will be set to 214748364...
+      */
+
+#define STRCUTOFF 214748364
+
+      int64_t x2 = (int64_t)(neg ? ~x+1u : x);
+      if (x2 > STRCUTOFF)
+        x2 = INT32_MAX;
+      else if (x2 < STRCUTOFF)
+        x2 = INT32_MIN;
+
+#undef STRCUTOFF
+
       if (fmt == STRSCAN_NUM)
-        setnumV(o, (lua_Number)(int32_t)(neg ? ~x+1u : x));
+        setnumV(o, (lua_Number)(int32_t)x2);
       else
-        setintV(o, (int32_t)(neg ? ~x+1u : x));
+        setintV(o, (int32_t)x2);
+    }
 #else
       fmt = strscan_dec(sp, o, fmt, opt, ex, neg, dig);
 #endif


### PR DESCRIPTION
not sure if this is 100% correct, but this seems to match up with what strtol does 
unsure if other stuff in lj_strscan_scan also needs this applied, but using a test script that prints a large number, this matches blua on platforms with 32bit wide long