### PR TITLE
prevent strscan wraparound and make it consistent with "32bit wide long"

### DIFF
--- a/src/lj_strscan.c
+++ b/src/lj_strscan.c
@@ -442,7 +442,8 @@ StrScanFmt lj_strscan_scan(const uint8_t *p, MSize len, TValue *o,
     int cmask = LJ_CHAR_DIGIT;
     int base = (opt & STRSCAN_OPT_C) && *p == '0' ? 0 : 10;
     const uint8_t *sp, *dp = NULL;
-    uint32_t dig = 0, hasdig = 0, x = 0;
+    uint32_t dig = 0, hasdig = 0;
+    uint64_t x = 0; // prevent wraparound
     int32_t ex = 0;
 
     /* Determine base and skip leading zeros. */
@@ -478,6 +479,10 @@ StrScanFmt lj_strscan_scan(const uint8_t *p, MSize len, TValue *o,
       }
     }
     if (!(hasdig | dig)) return STRSCAN_ERROR;
+
+    // gotta keep it consistent with windows and 32bit systems Zzz...
+    if (x > INT32_MAX)
+      x = INT32_MAX;
 
     /* Handle decimal point. */
 #if LJ_INTONLY


### PR DESCRIPTION
Ok different approach lol
The before was just plain wrong, due to not quite understanding strtols and luajits behaviour
This just prevents the digits from wrapping around in the first place and also ensuring its within the 32bit range to ensure consistency with lua, windows and 32bit builds